### PR TITLE
Runs all of the gosu build steps inside containers.

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -40,7 +40,8 @@ cp pkg/build/dumb-init/dumb-init pkg/rootfs/bin
 git clone https://github.com/tianon/gosu.git pkg/build/gosu
 pushd pkg/build/gosu
 git checkout -q "tags/$GOSU_TAG"
-./build.sh
+docker build --pull -t gosu .
+docker run --rm gosu bash -c 'cd /go/bin && tar -c gosu*' | tar -xv
 popd
 cp pkg/build/gosu/gosu-amd64 pkg/rootfs/bin/gosu
 


### PR DESCRIPTION
Pulled the build steps we actually needed out of the gosu build script and put them in build.sh. This eliminates some steps and dependencies we didn't need (this still depends on `tar` but that's ok for now).
